### PR TITLE
Each request should only affect itself and not other requests

### DIFF
--- a/ModuleConfig.cfc
+++ b/ModuleConfig.cfc
@@ -14,7 +14,7 @@ component {
 	function configure() {
 		settings = {
 			// Override in config to be true if not using URL Rewrites
-			includeIndex = false;
+			includeIndex = false
 		};
 	
 		interceptors = [

--- a/ModuleConfig.cfc
+++ b/ModuleConfig.cfc
@@ -12,6 +12,11 @@ component {
 	this.dependencies 		= [];
 
 	function configure() {
+		settings = {
+			// Override in config to be true if not using URL Rewrites
+			includeIndex = false;
+		};
+	
 		interceptors = [
 			{ name='SESOnRequest', class='#moduleMapping#.interceptors.SESOnRequest' }
 		];

--- a/interceptors/SESOnRequest.cfc
+++ b/interceptors/SESOnRequest.cfc
@@ -1,10 +1,10 @@
 component extends='coldbox.system.Interceptor' {
-    property name='includeIndex' inject='coldbox:setting:includeIndex@SESOnRequest';
+    property name='includeIndex' inject='coldbox:setting:includeIndex@ses-on-request';
     
     public void function preProcess(event, interceptData) {
         var SESBaseURL = event.isSSL() ? "https://" : "http://";
         SESBaseURL &= cgi.http_host;
-        if( SESOnRequestSettings.includeIndex ) {
+        if( includeIndex ) {
             SESBaseURL &= "/index.cfm";
         }
         event.setSESBaseURL( SESBaseURL );

--- a/interceptors/SESOnRequest.cfc
+++ b/interceptors/SESOnRequest.cfc
@@ -1,8 +1,7 @@
 component extends='coldbox.system.Interceptor' {
 
     public void function preProcess(event, interceptData) {
-        setSetting('HTMLBaseUrl', 'http://' & CGI.HTTP_HOST);
-        setSetting('SESBaseUrl', 'http://' & CGI.HTTP_HOST);
+        event.setSESBaseURL( ( event.isSSL() ? "https://" : "http://" ) & cgi.http_host & "/index.cfm");
     }
 
 }

--- a/interceptors/SESOnRequest.cfc
+++ b/interceptors/SESOnRequest.cfc
@@ -1,5 +1,5 @@
 component extends='coldbox.system.Interceptor' {
-    property name='SESOnRequestSettings' inject='coldbox:moduleSettings:SESOnRequest';
+    property name='includeIndex' inject='coldbox:setting:includeIndex@SESOnRequest';
     
     public void function preProcess(event, interceptData) {
         var SESBaseURL = event.isSSL() ? "https://" : "http://";

--- a/interceptors/SESOnRequest.cfc
+++ b/interceptors/SESOnRequest.cfc
@@ -1,7 +1,13 @@
 component extends='coldbox.system.Interceptor' {
-
+    property name='SESOnRequestSettings' inject='coldbox:moduleSettings:SESOnRequest';
+    
     public void function preProcess(event, interceptData) {
-        event.setSESBaseURL( ( event.isSSL() ? "https://" : "http://" ) & cgi.http_host & "/index.cfm");
+        var SESBaseURL = event.isSSL() ? "https://" : "http://";
+        SESBaseURL &= cgi.http_host;
+        if( SESOnRequestSettings.includeIndex ) {
+            SESBaseURL &= "/index.cfm";
+        }
+        event.setSESBaseURL( SESBaseURL );
     }
 
 }


### PR DESCRIPTION
Changing the ColdBox setting on each request is inherently not thread safe.  The preProcess interceptor should only affect the value for that request.  Otherwise, if two requests come through at the same time for different domains, they're be conflicting with each other.  All access to these URLs should be vai the `event` object, not via a setting.

```
event.getSESBaseURL()
event.getHTMLBaseURL()
```